### PR TITLE
Require coala~=0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-coala_bears>=0.8.0.dev20160710180716
-coala_utils>=0.4.7
+coala_bears~=0.9
+coala_utils~=0.4


### PR DESCRIPTION
aafd7bbc introduced usage of get_filtered_bears's new parameter
arg_parser added in https://github.com/coala/coala/commit/56bdf0b23
which was first released in coala 0.9.0

Also update the coala-utils dependency to use `~=` syntax.