### PR TITLE
Replace coalib.misc.ContextManagers with coala_utils.ContextManagers

### DIFF
--- a/tests/generation/Bears.py
+++ b/tests/generation/Bears.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 
 from pyprint.ConsolePrinter import ConsolePrinter
 from coalib.output.printers.LogPrinter import LogPrinter
-from coalib.misc.ContextManagers import retrieve_stdout
+from coala_utils.ContextManagers import retrieve_stdout
 from coala_quickstart.generation.Bears import (
     filter_relevant_bears, print_relevant_bears)
 

--- a/tests/generation/FileGlobs.py
+++ b/tests/generation/FileGlobs.py
@@ -3,7 +3,7 @@ import unittest
 
 from pyprint.ConsolePrinter import ConsolePrinter
 from coalib.output.printers.LogPrinter import LogPrinter
-from coalib.misc.ContextManagers import (
+from coala_utils.ContextManagers import (
     simulate_console_inputs, suppress_stdout)
 from coala_quickstart.generation.FileGlobs import get_project_files
 from coala_quickstart.generation.Utilities import get_gitignore_glob

--- a/tests/generation/Project.py
+++ b/tests/generation/Project.py
@@ -1,7 +1,7 @@
 import unittest
 
 from pyprint.ConsolePrinter import ConsolePrinter
-from coalib.misc.ContextManagers import retrieve_stdout
+from coala_utils.ContextManagers import retrieve_stdout
 from coala_quickstart.generation.Project import (
     get_used_languages, print_used_languages)
 

--- a/tests/interaction/Logo.py
+++ b/tests/interaction/Logo.py
@@ -1,7 +1,7 @@
 import unittest
 
 from pyprint.ConsolePrinter import ConsolePrinter
-from coalib.misc.ContextManagers import retrieve_stdout
+from coala_utils.ContextManagers import retrieve_stdout
 from coala_quickstart.interaction.Logo import (
     print_welcome_message, print_side_by_side)
 


### PR DESCRIPTION
Replaced import statements in
* test/generation/Bears.py
* test/generation/FileGlobs.py
* test/generation/Project.py
* tests/interaction/Logo.py
with corresponding from coala_utils.ContextManagers

Fixes https://github.com/coala/coala-quickstart/issues/54