### PR TITLE
Replace PEP8Bear with PycodestyleBear

### DIFF
--- a/coala_quickstart/Constants.py
+++ b/coala_quickstart/Constants.py
@@ -8,4 +8,4 @@ IMPORTANT_BEAR_LIST = {
     'CSS': {'CSSLintBear', 'SpaceConsistencyBear'},
     "JavaScript": {"JSHintBear", "JSComplexityBear"},
     "Java": {"JavaPMD", "CheckstyleBear"},
-    "Python": {"PEP8Bear"}}
+    "Python": {"PycodestyleBear"}}

--- a/tests/generation/Bears.py
+++ b/tests/generation/Bears.py
@@ -30,4 +30,4 @@ class TestBears(unittest.TestCase):
         with retrieve_stdout() as custom_stdout:
             print_relevant_bears(self.printer, filter_relevant_bears(
                 [('Python', 70), ('Unknown', 30)]))
-            self.assertIn("PEP8Bear", custom_stdout.getvalue())
+            self.assertIn("PycodestyleBear", custom_stdout.getvalue())


### PR DESCRIPTION
Change the important Bear for python language from
PEP8Bear to PycodestyleBear

Closes https://github.com/coala/coala-quickstart/issues/53