### PR TITLE
Removed python 3.3 dependency

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -3,9 +3,8 @@ set -x
 
 # Choose the python versions to install deps for
 case $CIRCLE_NODE_INDEX in
- *) dep_versions=( "3.3.6" ) ;;
- 1) dep_versions=( "3.4.3" ) ;;
- 2) dep_versions=( "3.5.1" ) ;;
+ *) dep_versions=( "3.4.3" ) ;;
+ 1) dep_versions=( "3.5.1" ) ;;
 esac
 
 for dep_version in "${dep_versions[@]}" ; do


### PR DESCRIPTION
Changed the file .ci/deps.sh so that it doesn't support python3.3
anymore as python3.3 hasn't been supported by coala for a long time.
see https://github.com/coala/coala-quickstart/issues/35

Closes https://github.com/coala/coala-quickstart/issues/57