### PR TITLE
FileGlobs.py: bypass the question

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,12 @@ coala-quickstart: personalized coala setup for your project
 coala-quickstart is a tool that helps users to quickly get started
 with coala. It can generate a ``.coafile`` (
 `coala <https://github.com/coala/coala>`__'s configuration
-file) that is tailored perfectly for your project without any
-interaction. This supports projects in several languages, including
-popular languages such as C/C++, Python, JavaScript, CSS, Java.
+file) that is tailored to your project. This supports projects in
+several languages, including popular languages such as C/C++, Python,
+JavaScript, CSS, Java.
+
+Please note that you will want do manually adapt the configuration to
+your needs!
 
 -----
 

--- a/coala_quickstart/coala_quickstart.py
+++ b/coala_quickstart/coala_quickstart.py
@@ -50,17 +50,20 @@ def main():
     log_printer = LogPrinter(printer)
 
     project_dir = os.getcwd()
+    is_CI_mode = True
     if not args.non_interactive:
         print_welcome_message(printer)
         project_dir = ask_question(
             "What is your project directory?",
             default=project_dir,
             typecast=valid_path)
+        is_CI_mode = False
 
     project_files, ignore_globs = get_project_files(
         log_printer,
         printer,
-        project_dir)
+        project_dir,
+        is_CI_mode)
 
     used_languages = list(get_used_languages(project_files))
     print_used_languages(printer, used_languages)
@@ -79,3 +82,4 @@ def main():
         ignore_globs,
         relevant_bears)
     write_coafile(printer, project_dir, settings)
+

--- a/coala_quickstart/generation/FileGlobs.py
+++ b/coala_quickstart/generation/FileGlobs.py
@@ -7,7 +7,7 @@ from coala_quickstart.Strings import GLOB_HELP
 from coalib.collecting.Collectors import collect_files
 
 
-def get_project_files(log_printer, printer, project_dir):
+def get_project_files(log_printer, printer, project_dir, is_CI_mode):
     """
     Gets the list of files matching files in the user's project directory
     after prompting for glob expressions.
@@ -16,6 +16,8 @@ def get_project_files(log_printer, printer, project_dir):
         A ``LogPrinter`` object.
     :param printer:
         A ``ConsolePrinter`` object.
+    :param is_CI_mode:
+        The running mode for coala-quickstart.
     :return:
         A list of file paths matching the files.
     """
@@ -27,6 +29,12 @@ def get_project_files(log_printer, printer, project_dir):
                       "will be automatically loaded as the files to ignore.",
                       color="green")
         ignore_globs = get_gitignore_glob(project_dir)
+
+    if is_CI_mode:
+        if ignore_globs is None:
+            file = open(".gitignore", "w")
+            file.write(".directory")
+            ignore_globs = get_gitignore_glob(project_dir)
 
     if ignore_globs is None:
         printer.print(GLOB_HELP)
@@ -50,3 +58,4 @@ def get_project_files(log_printer, printer, project_dir):
         ignored_file_paths=ignore_path_globs)
 
     return file_paths, ignore_globs
+


### PR DESCRIPTION
In CI mode there is no need to ask which files
to ignore, because the process is waiting for an
user to answer.
It's needed to bypass the "files to ignore" question.

Closes: https://github.com/coala/coala-quickstart/issues/49