### PR TITLE
FileGlobs.py: bypass the question

### DIFF
--- a/coala_quickstart/coala_quickstart.py
+++ b/coala_quickstart/coala_quickstart.py
@@ -50,17 +50,20 @@ def main():
     log_printer = LogPrinter(printer)
 
     project_dir = os.getcwd()
+    is_CI_mode = True
     if not args.non_interactive:
         print_welcome_message(printer)
         project_dir = ask_question(
             "What is your project directory?",
             default=project_dir,
             typecast=valid_path)
+        is_CI_mode = False
 
     project_files, ignore_globs = get_project_files(
         log_printer,
         printer,
-        project_dir)
+        project_dir,
+        is_CI_mode)
 
     used_languages = list(get_used_languages(project_files))
     print_used_languages(printer, used_languages)

--- a/coala_quickstart/generation/FileGlobs.py
+++ b/coala_quickstart/generation/FileGlobs.py
@@ -7,7 +7,7 @@ from coala_quickstart.Strings import GLOB_HELP
 from coalib.collecting.Collectors import collect_files
 
 
-def get_project_files(log_printer, printer, project_dir):
+def get_project_files(log_printer, printer, project_dir, is_CI_mode):
     """
     Gets the list of files matching files in the user's project directory
     after prompting for glob expressions.
@@ -16,6 +16,8 @@ def get_project_files(log_printer, printer, project_dir):
         A ``LogPrinter`` object.
     :param printer:
         A ``ConsolePrinter`` object.
+    :param is_CI_mode:
+        The running mode for coala-quickstart.
     :return:
         A list of file paths matching the files.
     """

--- a/tests/generation/FileGlobs.py
+++ b/tests/generation/FileGlobs.py
@@ -15,6 +15,7 @@ class TestQuestion(unittest.TestCase):
     def setUp(self):
         self.printer = ConsolePrinter()
         self.log_printer = LogPrinter(self.printer)
+        self.is_CI_mode = True
 
     def test_get_project_files(self):
         orig_cwd = os.getcwd()
@@ -30,7 +31,8 @@ class TestQuestion(unittest.TestCase):
         open(os.path.join("ignore_dir", "src.js"), "w").close()
 
         with suppress_stdout(), simulate_console_inputs("ignore_dir/**"):
-            res, _ = get_project_files(self.log_printer, self.printer, os.getcwd())
+            res, _ = get_project_files(self.log_printer, self.printer, os.getcwd(),
+                self.is_CI_mode)
             self.assertIn(os.path.join(os.getcwd(), "src", "file.c"), res)
             self.assertIn(os.path.join(os.getcwd(), "root.c"), res)
             self.assertNotIn(os.path.join(os.getcwd(), "ignore_dir/src.c"), res)
@@ -91,8 +93,8 @@ __pycache__
         with suppress_stdout():
             self.assertEqual(
                 sorted(get_project_files(
-                    self.log_printer, self.printer, os.getcwd())[0]),
-                sorted(files))
+                    self.log_printer, self.printer, os.getcwd(),
+                self.is_CI_mode)[0]), sorted(files))
 
         os.remove(".gitignore")
         os.chdir(orig_cwd)


### PR DESCRIPTION
In CI mode there is no need to ask which files
to ignore, because the process is waiting for an
user to answer.
It's needed to bypass the "files to ignore" question.

Closes: https://github.com/coala/coala-quickstart/issues/49