### PR TITLE
FileGlobs: Bypass the "files to ignore" question

### DIFF
--- a/coala_quickstart/coala_quickstart.py
+++ b/coala_quickstart/coala_quickstart.py
@@ -60,7 +60,8 @@ def main():
     project_files, ignore_globs = get_project_files(
         log_printer,
         printer,
-        project_dir)
+        project_dir,
+        args.non_interactive)
 
     used_languages = list(get_used_languages(project_files))
     print_used_languages(printer, used_languages)

--- a/coala_quickstart/generation/FileGlobs.py
+++ b/coala_quickstart/generation/FileGlobs.py
@@ -7,7 +7,7 @@ from coala_quickstart.Strings import GLOB_HELP
 from coalib.collecting.Collectors import collect_files
 
 
-def get_project_files(log_printer, printer, project_dir):
+def get_project_files(log_printer, printer, project_dir, non_interactive):
     """
     Gets the list of files matching files in the user's project directory
     after prompting for glob expressions.
@@ -16,6 +16,8 @@ def get_project_files(log_printer, printer, project_dir):
         A ``LogPrinter`` object.
     :param printer:
         A ``ConsolePrinter`` object.
+    :param non_interactive:
+        Whether coala-quickstart is in non-interactive mode.
     :return:
         A list of file paths matching the files.
     """
@@ -27,6 +29,10 @@ def get_project_files(log_printer, printer, project_dir):
                       "will be automatically loaded as the files to ignore.",
                       color="green")
         ignore_globs = get_gitignore_glob(project_dir)
+
+    if non_interactive:
+        if ignore_globs is None:
+            ignore_globs = []
 
     if ignore_globs is None:
         printer.print(GLOB_HELP)

--- a/tests/generation/FileGlobs.py
+++ b/tests/generation/FileGlobs.py
@@ -30,7 +30,8 @@ class TestQuestion(unittest.TestCase):
         open(os.path.join("ignore_dir", "src.js"), "w").close()
 
         with suppress_stdout(), simulate_console_inputs("ignore_dir/**"):
-            res, _ = get_project_files(self.log_printer, self.printer, os.getcwd())
+            res, _ = get_project_files(
+                self.log_printer, self.printer, os.getcwd(), False)
             self.assertIn(os.path.join(os.getcwd(), "src", "file.c"), res)
             self.assertIn(os.path.join(os.getcwd(), "root.c"), res)
             self.assertNotIn(os.path.join(os.getcwd(), "ignore_dir/src.c"), res)
@@ -91,8 +92,8 @@ __pycache__
         with suppress_stdout():
             self.assertEqual(
                 sorted(get_project_files(
-                    self.log_printer, self.printer, os.getcwd())[0]),
-                sorted(files))
+                    self.log_printer, self.printer, os.getcwd(),
+                self.non_interactive)[0]), sorted(files))
 
         os.remove(".gitignore")
         os.chdir(orig_cwd)


### PR DESCRIPTION
In CI mode there is no need to ask which files
to ignore, because the process is waiting for an
user to answer.

Closes: https://github.com/coala/coala-quickstart/issues/49