### PR TITLE
Utilites.py: Add language detection from hashbang

### DIFF
--- a/coala_quickstart/Constants.py
+++ b/coala_quickstart/Constants.py
@@ -41,3 +41,5 @@ DEFAULT_CAPABILTIES = {
     'Code Simplification',
     'Complexity',
 }
+
+HASHBANG_REGEX = '(^#!(.*))'

--- a/coala_quickstart/generation/Project.py
+++ b/coala_quickstart/generation/Project.py
@@ -1,9 +1,12 @@
 import os
 import operator
 from collections import defaultdict
+import re
 
 from coala_utils.string_processing.StringConverter import StringConverter
 from coala_utils.Extensions import exts
+from coala_quickstart.generation.Utilities import get_language_from_hashbang
+from coala_quickstart.Constants import HASHBANG_REGEX
 
 
 def valid_path(path: StringConverter):
@@ -45,9 +48,20 @@ def language_percentage(file_paths):
     results = defaultdict(lambda: 0)
     for file_path in file_paths:
         ext = os.path.splitext(file_path)[1]
+
         if ext in exts:
             for lang in exts[ext]:
                 results[lang] += delta
+
+        elif os.path.exists(file_path):
+            with open(file_path, 'r') as data:
+                hashbang = data.readline()
+                if re.match(HASHBANG_REGEX, hashbang):
+                    language = get_language_from_hashbang(hashbang).lower()
+                    for ext in exts:
+                        for lang in exts[ext]:
+                            if language == lang.lower():
+                                results[lang.lower()] += delta
 
     return results
 

--- a/tests/generation/UtilitiesTest.py
+++ b/tests/generation/UtilitiesTest.py
@@ -6,7 +6,7 @@ from tests.test_bears.AllKindsOfSettingsDependentBear import (
     AllKindsOfSettingsDependentBear)
 from coala_quickstart.generation.Utilities import (
     get_default_args, get_all_args,
-    search_for_orig)
+    search_for_orig, get_language_from_hashbang)
 
 
 def foo():
@@ -67,3 +67,9 @@ class TestAdditionalFunctions(unittest.TestCase):
                           'use_tabs': False, 'max_line_lengths': 1000,
                           'no_chars': 79,
                           'chars': False, 'dependency_results': {}})
+
+    def test_get_language_from_hashbang(self):
+        self.assertEqual(get_language_from_hashbang('#!/usr/bin/env python'),
+                         'python')
+        self.assertEqual(get_language_from_hashbang('#!bin/bash'),
+                         'bash')


### PR DESCRIPTION
Add a get_language_from_hashbang function
which checks whether hashbang exists in a
file and returns the language used in that
file.

This get_language_from_hashbang()
is used in split_by_language()
and language_percentage()

Fixes #45