### PR TITLE
WIP Enhance `.coafile` by utilizing information from `Gruntfile.js` 

### DIFF
--- a/coala_quickstart/Constants.py
+++ b/coala_quickstart/Constants.py
@@ -1,11 +1,138 @@
 IMPORTANT_BEAR_LIST = {
-    'All': {'FilenameBear', 'InvalidLinkBear', 'LineCountBear'},
-    "C": {"GNUIndentBear", 'CSecurityBear', 'ClangComplexityBear'},
-    'C#': {'CPDBear', 'CSharpLintBear', 'SpaceConsistencyBear'},
-    'C++': {'GNUIndentBear', 'CPDBear', 'CPPCheckBear', 'CPPCleanBear',
-            'ClangComplexityBear'},
-    'CMake': {'CMakeLintBear', 'SpaceConsistencyBear'},
-    'CSS': {'CSSLintBear', 'SpaceConsistencyBear'},
+    "All": {"FilenameBear", "InvalidLinkBear", "LineCountBear"},
+    "C": {"GNUIndentBear", "CSecurityBear", "ClangComplexityBear"},
+    "C#": {"CPDBear", "CSharpLintBear", "SpaceConsistencyBear"},
+    "C++": {"GNUIndentBear", "CPDBear", "CPPCheckBear", "CPPCleanBear",
+            "ClangComplexityBear"},
+    "CMake": {"CMakeLintBear", "SpaceConsistencyBear"},
+    "CSS": {"CSSLintBear", "SpaceConsistencyBear"},
     "JavaScript": {"JSHintBear", "JSComplexityBear"},
     "Java": {"JavaPMD", "CheckstyleBear"},
     "Python": {"PycodestyleBear"}}
+
+NPM_BEARS_META = {
+    "eslint": {
+        "bears": ["ESLintBear"],
+        "languages": [
+            "JavaScript",
+            "JSX"
+        ]
+    },
+    "autoprefixer": {
+        "bears": ["CSSAutoPrefixBear"],
+        "languages": [
+            "CSS"
+        ]
+    },
+    "remark-lint": {
+        "bears": ["MarkdownBear"],
+        "languages": [
+            "Markdown"
+        ]
+    },
+    "coffeelint": {
+        "bears": ["CoffeeLintBear"],
+        "languages": [
+            "CoffeeScript"
+        ]
+    },
+    "ramllint": {
+        "bears": ["RAMLLintBear"],
+        "languages": [
+            "RAML"
+        ]
+    },
+    "complexity-report": {
+        "bears": ["JSComplexityBear"],
+        "languages": [
+            "JavaScript"
+        ]
+    },
+    "dockerfile_lint": {
+        "bears": ["DockerfileLintBear"],
+        "languages": [
+            "Dockerfile"
+        ]
+    },
+    "alex": {
+        "bears": ["AlexBear"],
+        "languages": [
+            "Natural Language"
+        ]
+    },
+    "eslint-plugin-import": {
+        "bears": ["ESLintBear"],
+        "languages": [
+            "JavaScript",
+            "JSX"
+        ]
+    },
+    "csslint": {
+        "bears": ["CSSLintBear"],
+        "languages": [
+            "CSS"
+        ]
+    },
+    "happiness": {
+        "bears": ["HappinessLintBear"],
+        "languages": [
+            "JavaScript"
+        ]
+    },
+    "jshint": {
+        "bears": ["JSHintBear"],
+        "languages": [
+            "JavaScript"
+        ]
+    },
+    "tslint": {
+        "bears": ["TSLintBear"],
+        "languages": [
+            "TypeScript"
+        ]
+    },
+    "typescript": {
+        "bears": ["TSLintBear"],
+        "languages": [
+            "TypeScript"
+        ]
+    },
+    "write-good": {
+        "bears": ["WriteGoodLintBear"],
+        "languages": [
+            "Natural Language"
+        ]
+    },
+    "postcss-cli": {
+        "bears": ["CSSAutoPrefixBear"],
+        "languages": [
+            "CSS"
+        ]
+    },
+    "remark-cli": {
+        "bears": ["MarkdownBear"],
+        "languages": [
+            "Markdown"
+        ]
+    },
+    "babel-eslint": {
+        "bears": ["ESLintBear"],
+        "languages": [
+            "JavaScript",
+            "JSX"
+        ]
+    },
+    "stylelint": {
+        "bears": ["StyleLintBear"],
+        "languages": [
+            "CSS",
+            "SCSS"
+        ]
+    },
+    "bootlint": {
+        "bears": ["BootLintBear"],
+        "languages": [
+            "HTML"
+        ]
+    }
+}

--- a/coala_quickstart/coala_quickstart.py
+++ b/coala_quickstart/coala_quickstart.py
@@ -13,7 +13,7 @@ from coala_quickstart.generation.Project import (
 from coala_quickstart.generation.FileGlobs import get_project_files
 from coala_quickstart.generation.Bears import (
     filter_relevant_bears,
-    print_relevant_bears,
+    print_relevant_bears_by_language,
     get_non_optional_settings_bears,
     remove_unusable_bears,
 )
@@ -66,12 +66,12 @@ def main():
     print_used_languages(printer, used_languages)
 
     relevant_bears = filter_relevant_bears(used_languages, arg_parser)
-    print_relevant_bears(printer, relevant_bears)
+    print_relevant_bears_by_language(printer, relevant_bears)
 
     if args.non_interactive:
         unusable_bears = get_non_optional_settings_bears(relevant_bears)
         remove_unusable_bears(relevant_bears, unusable_bears)
-        print_relevant_bears(printer, relevant_bears, 'usable')
+        print_relevant_bears_by_language(printer, relevant_bears, 'usable')
 
     settings = generate_settings(
         project_dir,

--- a/coala_quickstart/generation/Bears.py
+++ b/coala_quickstart/generation/Bears.py
@@ -97,7 +97,7 @@ def remove_unusable_bears(bears, unusable_bears):
                 bears[language].remove(bear)
 
 
-def print_relevant_bears(printer, relevant_bears, label='relevant'):
+def print_relevant_bears_by_language(printer, relevant_bears, label='relevant'):
     """
     Prints the relevant bears in sections separated by language.
 
@@ -115,4 +115,30 @@ def print_relevant_bears(printer, relevant_bears, label='relevant'):
         printer.print("    [" + language + "]", color="green")
         for bear in relevant_bears[language]:
             printer.print("    " + bear.name, color="cyan")
+        printer.print("")
+
+
+def print_relevant_bears_by_linter(printer,
+                                   source,
+                                   relevant_bears,
+                                   label="relevant"):
+    """
+    Prints the relevant bears in sections separated by corresponding
+    linter names.
+
+    :param printer:
+        A ``ConsolePrinter`` object used for console interactions.
+    :param source:
+        A string containing info about the source of information of
+        the relevance of bears.
+    :param relevant_bears:
+        A dict with linter name as key and bear names as value.
+    """
+
+    printer.print("\nBased on the %s used in project the following "
+                  "bears have been identified to be %s:" % (source, label))
+    for linter in relevant_bears:
+        printer.print("    [" + linter + "]", color="green")
+        for bear in relevant_bears[linter]:
+            printer.print("    " + bear, color="cyan")
         printer.print("")

--- a/coala_quickstart/generation/Settings.py
+++ b/coala_quickstart/generation/Settings.py
@@ -9,12 +9,14 @@ from coalib.settings.SectionFilling import fill_settings
 from coalib.output.printers.LogPrinter import LogPrinter
 from coala_quickstart.generation.Utilities import (
     split_by_language, get_extensions)
+from coala_quickstart.generation.parse_gruntfile import get_gruntfile_info
 from coalib.settings.Section import Section
 from coalib.output.ConfWriter import ConfWriter
 from coalib.collecting.Collectors import collect_files
+from coala_quickstart.generation.Bears import print_relevant_bears_by_linter
 
 
-def generate_section(section_name, extensions_used, bears):
+def generate_section(section_name, extensions_used, bears, used_bears=[]):
     """
     Generates a section for a particular language (or default).
 
@@ -24,15 +26,68 @@ def generate_section(section_name, extensions_used, bears):
         A list of extensions associated with this section.
     :param bears:
         A list of bear classes.
+    :param used_bears:
+        A list of names of the bears already used in other section.
     :return:
         A ``Section`` object containing the section.
     """
     section = Section(section_name, None)
-
-    section["bears"] = ", ".join(bear.name for bear in bears)
+    bears = [bear.name for bear in bears if bear.name not in used_bears]
+    section["bears"] = ", ".join(bear for bear in bears)
     section["files"] = ", ".join("**" + ext for ext in set(extensions_used))
-
     return section
+
+
+def generate_sections_from_gruntfile(project_dir, project_files):
+    gruntfile_info = get_gruntfile_info(project_dir)
+    printer = ConsolePrinter()
+    sections = []
+    no_match_linters = []
+
+    for info in gruntfile_info:
+        if info.get("bears"):
+            section_name = "gruntfile_" + info["linter"]
+            section = Section(section_name, None)
+            section["bears"] = ", ".join(bear for bear in info["bears"])
+            if info.get("include"):
+                section["files"] = ", ".join(
+                    [path for path in set(info["include"])])
+            else:
+                files_from_languages = get_files_from_languages(
+                    project_dir, project_files, info["languages"])
+                if files_from_languages:
+                    section["files"] = ", ".join(files_from_languages)
+                else:
+                    print("No files found")
+                    continue
+            if info.get("ignore"):
+                section["files"] = info["ignore"]
+            sections.append(section)
+        else:
+            no_match_linters.append(info["linter"])
+
+    if no_match_linters:
+        printer.print(
+            "coala-quickstart could not identify following parts"
+            " of Gruntile.js : {}".format(" ".join(no_match_linters)))
+
+    bears_by_linter = {info["linter"]: info["bears"]
+                       for info in gruntfile_info if info.get("bears")}
+    print_relevant_bears_by_linter(printer, "Gruntfile.js", bears_by_linter)
+
+    return sections
+
+
+def get_files_from_languages(project_dir, project_files, languages):
+    lang_files = split_by_language(project_files)
+    print("lang_files:", lang_files.keys(), languages)
+    results = set()
+    for lang in languages:
+        if lang_files.get(lang.lower()):
+            print("lang found")
+            for file in lang_files[lang.lower()]:
+                results.add(os.path.relpath(file, project_dir))
+    return results
 
 
 def generate_ignore_field(project_dir, languages, extset, ignore_globs):
@@ -84,7 +139,6 @@ def generate_settings(project_dir, project_files, ignore_globs, relevant_bears):
     lang_map = {lang.lower(): lang for lang in relevant_bears}
     lang_files = split_by_language(project_files)
     extset = get_extensions(project_files)
-
     settings = OrderedDict()
 
     settings["default"] = generate_section(
@@ -98,12 +152,20 @@ def generate_settings(project_dir, project_files, ignore_globs, relevant_bears):
     if ignored_files:
         settings["default"]["ignore"] = ignored_files
 
+    used_bears = []
+    gruntfile_sections = generate_sections_from_gruntfile(
+        project_dir, project_files)
+    for sec in gruntfile_sections:
+        settings[sec.name] = sec
+        used_bears.append(str(sec["bears"]))
+
     for lang in lang_files:
         if lang != "unknown" and lang != "all":
             settings[lang_map[lang]] = generate_section(
                 lang,
                 extset[lang],
-                relevant_bears[lang_map[lang]])
+                relevant_bears[lang_map[lang]],
+                used_bears)
 
     log_printer = LogPrinter(ConsolePrinter())
     fill_settings(settings, acquire_settings, log_printer)

--- a/coala_quickstart/generation/parse_gruntfile.py
+++ b/coala_quickstart/generation/parse_gruntfile.py
@@ -1,0 +1,227 @@
+import os
+from coala_quickstart.Constants import NPM_BEARS_META
+from coala_quickstart.generation.Utilities import search_dict_recursively
+
+from pyjsparser import PyJsParser
+
+PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def parse_javascript_file(file_path):
+    """
+    Returns an instance of PyJsParser created
+    from the given `file_path`
+    """
+    source_code = ''
+    with open(file_path, 'r') as file:
+        source_code = file.read()
+    if source_code:
+        js_parser = PyJsParser()
+        parsed_code = js_parser.parse(source_code)
+        return parsed_code
+    return None
+
+
+def extract_lint_subtasks_from_gruntfile(parsed_file):
+    """
+    Extract the lint subtasks from the parsed JS file.
+    Looks for identifiers like:
+    grunt.registerTask( 'lint', [ 'csslint', 'jshint' ] );
+
+    :param parsed_file:
+        An instance of PyJsParser().parse
+    :return:
+        A list of lint_subtasks
+    """
+    keys_to_match = ['lint']
+
+    # Serch for grunt.registerTask() identifiers
+    search_results = search_dict_recursively(parsed_file, "callee", {
+        "computed": False,
+        "type": "MemberExpression",
+        "property": {
+            "name": "registerTask",
+            "type": "Identifier"
+        },
+        "object": {
+            "name": "grunt",
+            "type": "Identifier"
+        }
+        })
+
+    lint_subtasks = []
+    is_lint = False
+
+    for res in search_results:
+        arguments = res["object"].get('arguments')
+        if arguments:
+            for arg in arguments:
+                if arg.get('value') in keys_to_match:
+                    is_lint = True
+                    break
+        if is_lint:
+            for arg in arguments:
+                if "elements" in arg.keys() and \
+                        arg["type"] == "ArrayExpression":
+                    lint_subtasks = [
+                        elem["value"].split(':')[0]
+                        for elem in arg["elements"]
+                    ]
+            return lint_subtasks
+
+
+def get_configurations_from_gruntfile(parsed_file, tasks):
+    """
+    Extract the configurations from the PyJsParser instance
+    of a Gruntfile and return configuration data(if any) of
+    the task provided. Looks for patterns like
+    {
+        grunt.initConfig(
+            {
+                some configuration objects
+            }
+    }
+
+    :param parsed_file:
+        An instance of PyJsParser().parse
+    :return:
+        A list of configuration dicts
+    """
+    init_config_data = {}
+    result = {}
+    search_results = search_dict_recursively(
+        parsed_file, "callee",
+        {
+            "computed": False,
+            "type": "MemberExpression",
+            "property": {
+                "name": "initConfig",
+                "type": "Identifier"
+                },
+            "object": {
+                "name": "grunt",
+                "type": "Identifier"
+                }
+        })
+    if search_results:
+        init_config_data = search_results[0]["object"]
+        arguments = init_config_data.get('arguments')
+        if arguments:
+            for arg in arguments:
+                if arg.get("properties"):
+                    for p in arg["properties"]:
+                        if p["key"]["name"] in tasks:
+                            name = p["key"]["name"]
+                            result[name] = p["value"]
+    return result
+
+
+def extract_literals_from_expression(obj):
+    """
+    From the given expression of PyJsParser.parse() instance,
+    return the elements of type "Literal" by searching recursively.
+    """
+    results = []
+    if obj.get("type") == "ArrayExpression" and "elements" in obj.keys():
+        results = [
+            elem["value"]
+            for elem in obj["elements"] if elem["type"] == "Literal"
+        ]
+
+    elif obj.get("type") == "ObjectExpression":
+        if obj["value"]["type"] == "ArrayExpression" and \
+                "elements" in obj["value"].keys():
+            results = [
+                elem["value"]
+                for elem in obj["elements"] if elem["type"] == "Literal"
+            ]
+        else:
+            return extract_literals_from_expression(obj["value"])
+
+    elif obj.get("type") == "Property":
+        return extract_literals_from_expression(obj["value"])
+
+    return results
+
+
+def extract_globs_from_parsefile(parsed_config):
+    """
+    Extract the path glob literals matching ceratin keys
+     from the PyJsParser().parse instance.
+
+    :param parsed_file:
+        An instance of PyJsParser().parse
+    :return:
+        A dictionary with keys `use` and `ignore` and values being the
+        corresponding list of globs.
+    """
+    to_use_keys = ['all', 'main', 'files', 'src', 'sources']
+    to_ignore_keys = ['ignore', 'exclude']
+
+    result = {
+        "include": [],
+        "ignore": []
+    }
+    if parsed_config.get("type") == "ObjectExpression":
+        for prop in parsed_config["properties"]:
+            if prop["key"]["name"] in to_use_keys:
+                result["include"] = extract_literals_from_expression(prop)
+            elif prop["key"]["name"] in to_ignore_keys:
+                result["ignore"] = extract_elements_from_array_expression(prop)
+    return result
+
+
+def get_gruntfile_info(project_dir, filename="Gruntfile.js"):
+    """
+    Extract useful information from the `Gruntfile.js` of the project
+
+    :param project_dir:
+        Directory of the project
+    :param filename:
+        Name of the file, default `Gruntfile.js`
+    :return:
+        A list of dicts of the form
+        {
+            "linter": name of the lint-subtask,
+            "bears": list of matching bears to the linter,
+            "languages": list of languages affected by the linter,
+            "include": list of file globs to include for the linter,
+            "ignore": list of file globs to ignore for the linter,
+        }
+    """
+    gruntfile = os.path.join(project_dir, filename)
+
+    parsed_gruntfile = parse_javascript_file(gruntfile)
+
+    linters = extract_lint_subtasks_from_gruntfile(parsed_gruntfile)
+
+    config = get_configurations_from_gruntfile(parsed_gruntfile, linters)
+
+    results = []
+
+    for linter in linters[:]:
+        linter_result = {
+            "linter": linter,
+            "bears": [],
+            "languages": [],
+            "include": [],
+            "ignore": []
+        }
+
+        matching_bear = None
+
+        if NPM_BEARS_META.get(linter):
+            matching_bear = NPM_BEARS_META[linter]
+            linter_result["bears"] = matching_bear["bears"]
+            linter_result["languages"] = matching_bear["languages"]
+
+        if matching_bear and config.get(linter):
+            globs = extract_globs_from_parsefile(config[linter])
+            if globs.get("include"):
+                linter_result["include"] = globs["include"]
+            if globs.get("ignore"):
+                linter_result["ignore"] = globs["ignore"]
+
+        results.append(linter_result)
+
+    return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 coala_bears~=0.9
 coala_utils~=0.4
+pyjsparser~=2.4.5


### PR DESCRIPTION
Test run after putting the `Gruntfile.js` from https://github.com/wikimedia/jquery.ime/blob/master/Gruntfile.js into the `coala-quickstart/coala-quickstart` directory.

```
'use strict';

/* jshint node: true */
module.exports = function ( grunt ) {
	grunt.loadNpmTasks( 'grunt-contrib-concat' );
	grunt.loadNpmTasks( 'grunt-contrib-copy' );
	grunt.loadNpmTasks( 'grunt-contrib-csslint' );
	grunt.loadNpmTasks( 'grunt-contrib-cssmin' );
	grunt.loadNpmTasks( 'grunt-contrib-jshint' );
	grunt.loadNpmTasks( 'grunt-contrib-qunit' );
	grunt.loadNpmTasks( 'grunt-contrib-uglify' );
	grunt.loadNpmTasks( 'grunt-contrib-watch' );
	grunt.loadNpmTasks( 'grunt-jscs' );
	// Project configuration.
	grunt.initConfig( {
		pkg: grunt.file.readJSON( 'package.json' ),
		meta: {
			banner: '/*! <%= pkg.title || pkg.name %> - v<%= pkg.version %>+'
				+ '<%= grunt.template.today("yyyymmdd") %>\n'
				+ '<%= pkg.homepage ? "* " + pkg.homepage + "\\n" : "" %>'
				+ '* Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author.name %>;'
				+ ' Licensed <%= _.pluck(pkg.licenses, "type").join(", ") %> */\n'
		},
		concat: {
			options: {
				banner: '<%= meta.banner %>'
			},
			dist: {
				src: [
					'src/jquery.ime.js',
					'src/jquery.ime.selector.js',
					'src/jquery.ime.preferences.js',
					'src/jquery.ime.inputmethods.js'
				],
				dest: 'dist/jquery.ime/<%= pkg.name %>.js'
			}
		},
		uglify: {
			options: {
				banner: '<%= meta.banner %>'
			},
			dist: {
				files: {
					'dist/jquery.ime/<%= pkg.name %>.min.js': [
						'src/jquery.ime.js',
						'src/jquery.ime.selector.js',
						'src/jquery.ime.preferences.js',
						'src/jquery.ime.inputmethods.js',
						'libs/rangy/rangy-core.js'
					]
				}
			}
		},
		copy: {
			dist: {
				files: {
					'dist/jquery.ime/': [
						'rules/**',
						'images/**',
						'css/**'
					]
				}
			}
		},
		qunit: {
			files: [ 'test/index.html' ]
		},
		jshint: {
			options: {
				jshintrc: true
			},
			all: [
				'*.js',
				'src/*.js',
				'rules/**/*.js',
				'test/**/*.js'
			]
		},
		jscs: {
			fix: {
				options: {
					fix: true
				},
				src: '<%= jshint.all %>'
			},
			main: {
				src: '<%= jshint.all %>'
			}
		},
		csslint: {
			all: [
				'css/**/*.css'
			]
		},
		watch: {
			files: [
				'.{csslintrc,jscsrc,jshintignore,jshintrc}',
				'<%= jshint.all %>',
				'<%= csslint.all %>'
			],
			tasks: 'lint'
		}
	} );

	// Default task.
	grunt.registerTask( 'lint', [ 'jshint', 'jscs:main', 'csslint' ] );
	grunt.registerTask( 'build', [ 'concat', 'uglify', 'copy' ] );
	grunt.registerTask( 'test', [ 'build', 'qunit' ] );
	grunt.registerTask( 'default', [ 'lint', 'test' ] );
};

```
![screenshot from 2017-02-17 16-56-09](https://cloud.githubusercontent.com/assets/10217535/23065506/dfbbd5de-f53b-11e6-9594-0f75dcc3f5fc.png)

And the generated `.coafile`:
**Now**
![screenshot from 2017-02-17 16-56-49](https://cloud.githubusercontent.com/assets/10217535/23065508/e456f77c-f53b-11e6-863c-043a376df4b8.png)

**Before**
![image](https://cloud.githubusercontent.com/assets/10217535/23152436/1756b592-f828-11e6-8e50-7e2c92af25b1.png)


cc @jayvdb 
