### PR TITLE
README.rst: Fix spelling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ file) that is tailored to your project. This supports projects in
 several languages, including popular languages such as C/C++, Python,
 JavaScript, CSS, Java.
 
-Please note that you will want do manually adapt the configuration to
+Please note that you will want to manually adapt the configuration to
 your needs!
 
 -----

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ several languages, including popular languages such as C/C++, Python,
 JavaScript, CSS, Java.
 
 Please note that you will want to manually adapt the configuration to
-your needs!
+your needs! 
 
 -----
 


### PR DESCRIPTION
I change 'do' -> 'to' at the README file

Closes https://github.com/coala/coala-quickstart/issues/81