### PR TITLE
Settings.py: Add --allow-incomplete-sections mode

### DIFF
--- a/coala_quickstart/coala_quickstart.py
+++ b/coala_quickstart/coala_quickstart.py
@@ -39,6 +39,11 @@ coala-quickstart automatically creates a .coafile for use by coala.
         '--ci', action='store_const', dest='non_interactive', const=True,
         help='continuous integration run, alias for `--non-interactive`')
 
+    arg_parser.add_argument(
+        '--allow-incomplete-sections', action='store_const',
+        dest='incomplete_sections', const=True,
+        help='generate coafile with only `bears` and `files` field in sections')
+
     return arg_parser
 
 
@@ -69,7 +74,7 @@ def main():
     relevant_bears = filter_relevant_bears(used_languages, arg_parser)
     print_relevant_bears(printer, relevant_bears)
 
-    if args.non_interactive:
+    if args.non_interactive and not args.incomplete_sections:
         unusable_bears = get_non_optional_settings_bears(relevant_bears)
         remove_unusable_bears(relevant_bears, unusable_bears)
         print_relevant_bears(printer, relevant_bears, 'usable')
@@ -78,5 +83,7 @@ def main():
         project_dir,
         project_files,
         ignore_globs,
-        relevant_bears)
+        relevant_bears,
+        args.incomplete_sections)
+
     write_coafile(printer, project_dir, settings)

--- a/coala_quickstart/generation/Settings.py
+++ b/coala_quickstart/generation/Settings.py
@@ -66,7 +66,8 @@ def generate_ignore_field(project_dir, languages, extset, ignore_globs):
     return ", ".join(ignores)
 
 
-def generate_settings(project_dir, project_files, ignore_globs, relevant_bears):
+def generate_settings(project_dir, project_files, ignore_globs, relevant_bears,
+                      incomplete_sections=False):
     """
     Generates the settings for the given project.
 
@@ -78,6 +79,17 @@ def generate_settings(project_dir, project_files, ignore_globs, relevant_bears):
         The list of ignore glob expressions.
     :param relevant_bears:
         A dict with language name as key and bear classes as value.
+    :param incomplete_sections:
+        When bears with non optional settings are found, user is asked for
+        setting value of non optional bears and then a ``Section`` object
+        having ``files`` field, ``bears`` field and settings, is returned.
+        If incomplete_sections is set to ``True``, then no user input will
+        be asked and a ``Section`` object having only the ``files`` and
+        ``bears`` field will be returned.
+
+        In CI mode, bears with non optional setting are not added in coafile.
+        But if incomplete_sections is set to ``True`` in CI mode, then those
+        bears are also added in the coafile.
     :return:
         A dict with section name as key and a ``Section`` object as value.
     """
@@ -106,7 +118,9 @@ def generate_settings(project_dir, project_files, ignore_globs, relevant_bears):
                 relevant_bears[lang_map[lang]])
 
     log_printer = LogPrinter(ConsolePrinter())
-    fill_settings(settings, acquire_settings, log_printer)
+
+    if not incomplete_sections:
+        fill_settings(settings, acquire_settings, log_printer)
 
     return settings
 

--- a/tests/generation/Bears.py
+++ b/tests/generation/Bears.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import unittest
 from copy import deepcopy
@@ -7,6 +8,8 @@ from coalib.output.printers.LogPrinter import LogPrinter
 from coala_utils.ContextManagers import retrieve_stdout
 from coala_quickstart.generation.Bears import (
     filter_relevant_bears, print_relevant_bears)
+from coala_quickstart.coala_quickstart import main
+
 
 class TestBears(unittest.TestCase):
 
@@ -31,3 +34,28 @@ class TestBears(unittest.TestCase):
             print_relevant_bears(self.printer, filter_relevant_bears(
                 [('Python', 70), ('Unknown', 30)]))
             self.assertIn("PycodestyleBear", custom_stdout.getvalue())
+
+    def test_bears_allow_incomplete_sections_mode(self):
+        sys.argv.append('--ci')
+        sys.argv.append('--allow-incomplete-sections')
+        orig_cwd = os.getcwd()
+        os.chdir(os.path.dirname(os.path.realpath(__file__)))
+        os.chdir("bears_ci_testfiles")
+        with retrieve_stdout() as custom_stdout:
+            main()
+            self.assertNotIn("usable", 
+                custom_stdout.getvalue())
+        os.remove('.coafile')
+        os.chdir(orig_cwd) 
+
+    def test_bears_ci_mode(self):
+        sys.argv.append('--ci')
+        orig_cwd = os.getcwd()
+        os.chdir(os.path.dirname(os.path.realpath(__file__)))
+        os.chdir("bears_ci_testfiles")
+        with retrieve_stdout() as custom_stdout:
+            main()
+            self.assertIn("usable", 
+                custom_stdout.getvalue())
+        os.remove('.coafile')
+        os.chdir(orig_cwd)   

--- a/tests/generation/SettingsTest.py
+++ b/tests/generation/SettingsTest.py
@@ -1,20 +1,28 @@
 import os
+import sys
 import tempfile
 import unittest
 from datetime import date
+from copy import deepcopy
 
 from coalib.output.ConfWriter import ConfWriter
-from coala_quickstart.generation.Settings import write_info
+from coala_quickstart.generation.Settings import write_info, generate_settings
+from coala_quickstart.generation.Bears import filter_relevant_bears
+from coala_quickstart.generation.Project import get_used_languages
+
 
 class SettingsTest(unittest.TestCase):
 
     def setUp(self):
         self.coafile = os.path.join(tempfile.gettempdir(), '.coafile')
         self.writer = ConfWriter(self.coafile)
+        self.old_argv = deepcopy(sys.argv)
+        del sys.argv[1:]
         
     def tearDown(self):
         self.writer.close()
         os.remove(self.coafile)
+        sys.argv = self.old_argv
         
     def test_write_info(self):
         result_date = date.today().strftime("%d %b %Y")
@@ -27,3 +35,24 @@ class SettingsTest(unittest.TestCase):
             line = f.readline()
             
         self.assertEqual(result_comment, line)
+
+    def test_allow_complete_section_mode(self):
+        project_dir = "/repo"
+        project_files = ['/repo/hello.html']
+        ignore_globs = []
+
+        used_languages = list(get_used_languages(project_files))
+        relevant_bears = filter_relevant_bears(used_languages)
+
+        res = generate_settings(
+            project_dir, project_files, ignore_globs, relevant_bears, True)
+
+        bears_list = res["HTML"]["bears"].value.replace(" ", "").split(",")
+
+        files_list = res["HTML"]["files"].value.replace(" ", "").split(",")
+
+        self.assertEqual(['HTMLLintBear', 'coalaBear', 'BootLintBear',
+            'LicenseCheckBear', 'SpaceConsistencyBear', 'KeywordBear',
+            'LineLengthBear', 'DuplicateFileBear'].sort(), bears_list.sort())
+
+        self.assertEqual(['**.html'], files_list)


### PR DESCRIPTION
Settings.py: Add --allow-incomplete-sections mode

In this running mode, coala-quickstart will not prompt the user to
enter settings of bears in non CI mode.

If this mode is selected with CI mode, then it includes unusable
bears as well in generated coafile, without prompting for settings.

Closes #93