### PR TITLE
coala_quickstart: Fix errors due to logging

### DIFF
--- a/coala_quickstart/coala_quickstart.py
+++ b/coala_quickstart/coala_quickstart.py
@@ -1,5 +1,7 @@
 import argparse
+import logging
 import os
+import sys
 
 from pyprint.ConsolePrinter import ConsolePrinter
 
@@ -57,6 +59,7 @@ def main():
     arg_parser = _get_arg_parser()
     args = arg_parser.parse_args()
 
+    logging.basicConfig(stream=sys.stdout)
     printer = ConsolePrinter()
     log_printer = LogPrinter(printer)
 


### PR DESCRIPTION
Configures the stream handler of the `logging` module
to be `stdout` to avoid ``ValueError`` while writing
to the log stream.

Fixes https://github.com/coala/coala-quickstart/issues/143