### PR TITLE
Bears: Silence .coafile not found warnings

### DIFF
--- a/coala_quickstart/generation/Bears.py
+++ b/coala_quickstart/generation/Bears.py
@@ -42,7 +42,8 @@ def filter_relevant_bears(used_languages,
     bears_by_lang = {
         lang: set(inverse_dicts(*get_filtered_bears([lang],
                                                     log_printer,
-                                                    arg_parser)).keys())
+                                                    arg_parser,
+                                                    silent=True)).keys())
         for lang, _ in used_languages
     }
 


### PR DESCRIPTION
Silences CLI warnings when ".coafile" is absent.

Fixes https://github.com/coala/coala-quickstart/issues/163

Requires https://github.com/coala/coala/pull/4622 to be fixed first