### PR TITLE
requirement.txt: Pin lxml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+#TODO: Remove lxml once the upstream issue https://github.com/vfaronov/httpolice/issues/5 with HTTpolice is fixed.
+lxml==3.6.0
 coala_bears~=0.12.0.dev20170722110839
 coala_utils~=0.4
 gemfileparser~=0.6.2


### PR DESCRIPTION
Pin lxml version to 3.6.0 as the recent version
3.8.0 which is required by HTTpolice is causing
the Appveyor builds to fail on 64-bit architecture.
This change temporarily fixes the issue until the
upstream issues are not resolved.

Related to https://github.com/coala/coala-quickstart/issues/166