### PR TITLE
Bears.py: Suggest bears based on Gruntfile.js

### DIFF
--- a/coala_quickstart/generation/InfoCollector.py
+++ b/coala_quickstart/generation/InfoCollector.py
@@ -4,6 +4,8 @@ from coala_quickstart.info_extractors.PackageJSONInfoExtractor import (
     PackageJSONInfoExtractor)
 from coala_quickstart.info_extractors.GemfileInfoExtractor import (
     GemfileInfoExtractor)
+from coala_quickstart.info_extractors.GruntfileInfoExtractor import (
+    GruntfileInfoExtractor)
 
 
 def collect_info(project_dir):
@@ -20,8 +22,11 @@ def collect_info(project_dir):
     gemfile_info = GemfileInfoExtractor(
         ["Gemfile"], project_dir).extract_information()
 
+    gruntfile_info = GruntfileInfoExtractor(
+        ["Gruntfile.js"], project_dir).extract_information()
+
     extracted_info = aggregate_info([
-        editorconfig_info, package_json_info, gemfile_info])
+        editorconfig_info, package_json_info, gemfile_info, gruntfile_info])
 
     return extracted_info
 

--- a/tests/test_bears/SomeLinterBear.py
+++ b/tests/test_bears/SomeLinterBear.py
@@ -1,0 +1,14 @@
+from coalib.bearlib.abstractions.Linter import linter
+
+
+@linter(executable='some_lint',
+        output_format='regex',
+        output_regex=r'.+:(?P<line>\d+):(?P<message>.*)')
+class SomeLinterBear:
+    CAN_DETECT = {'Syntax', 'Security'}
+    CAN_FIX = {'Formatting'}
+    LANGUAGES = {'Javascript'}
+
+    @staticmethod
+    def create_arguments(filename, file, config_file):
+        return ()


### PR DESCRIPTION
* Adds "Gruntfile.js" to the `collect_info` method in the InfoCollector
  module.
* Adds functionality to `filter_relevant_bears` method to suggest bears
  based on `LintTaskInfo` extracted from project similar to
  `ProjectDependencyInfo`.

Closes https://github.com/coala/coala-quickstart/issues/145