### PR TITLE
Settings.py: Generate new style sections

### DIFF
--- a/coala_quickstart/generation/Settings.py
+++ b/coala_quickstart/generation/Settings.py
@@ -103,8 +103,8 @@ def generate_settings(project_dir, project_files, ignore_globs, relevant_bears,
 
     settings = OrderedDict()
 
-    settings["default"] = generate_section(
-        "default",
+    settings["all"] = generate_section(
+        "all",
         [ext for lang in lang_files for ext in extset[lang]],
         relevant_bears[lang_map["all"]])
 
@@ -112,12 +112,12 @@ def generate_settings(project_dir, project_files, ignore_globs, relevant_bears,
                                           extset, ignore_globs)
 
     if ignored_files:
-        settings["default"]["ignore"] = ignored_files
+        settings["all"]["ignore"] = ignored_files
 
     for lang in lang_files:
         if lang != "unknown" and lang != "all":
-            settings[lang_map[lang]] = generate_section(
-                lang,
+            settings["all." + lang_map[lang]] = generate_section(
+                "all." + lang,
                 extset[lang],
                 relevant_bears[lang_map[lang]])
 

--- a/tests/generation/SettingsTest.py
+++ b/tests/generation/SettingsTest.py
@@ -54,9 +54,9 @@ class SettingsTest(unittest.TestCase):
         res = generate_settings(
             project_dir, project_files, ignore_globs, relevant_bears, {}, True)
 
-        bears_list = res["HTML"]["bears"].value.replace(" ", "").split(",")
+        bears_list = res["all.HTML"]["bears"].value.replace(" ", "").split(",")
 
-        files_list = res["HTML"]["files"].value.replace(" ", "").split(",")
+        files_list = res["all.HTML"]["files"].value.replace(" ", "").split(",")
 
         self.assertEqual(
             ['HTMLLintBear', 'coalaBear', 'BootLintBear',


### PR DESCRIPTION
The implicit `Default` section inheritance is deprecated and
quickstart needs to generate .coafile with new section styles.

Fixes https://github.com/coala/coala-quickstart/issues/127