### PR TITLE
coala_quickstart.py: Add version argument

### DIFF
--- a/coala_quickstart/coala_quickstart.py
+++ b/coala_quickstart/coala_quickstart.py
@@ -36,6 +36,9 @@ coala-quickstart automatically creates a .coafile for use by coala.
     )
 
     arg_parser.add_argument(
+        '-v', '--version', action='version', version='0.4.0')
+
+    arg_parser.add_argument(
         '-C', '--non-interactive', const=True, action='store_const',
         help='run coala-quickstart in non interactive mode')
 

--- a/tests/generation/Bears.py
+++ b/tests/generation/Bears.py
@@ -357,3 +357,17 @@ class TestBears(unittest.TestCase):
                                     if bear not in res_1[lang]]
                 for bear in additional_bears_by_lang[lang]:
                     self.assertIn(bear, additional_bears)
+
+    def test_print_coala_quickstart_version_short(self):
+        sys.argv.append('-v')
+        with retrieve_stdout() as custom_stdout:
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            self.assertEquals('0.4.0\n', custom_stdout.getvalue())
+
+    def test_print_coala_quickstart_version_long(self):
+        sys.argv.append('--version')
+        with retrieve_stdout() as custom_stdout:
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            self.assertEquals('0.4.0\n', custom_stdout.getvalue())


### PR DESCRIPTION
Add arguments '-v' and '--version' to the argparser, 
now `coala-quickstart -v` or `coala-quickstart --version` 
can print out the version of coala quickstart

Closes https://github.com/coala/coala-quickstart/issues/147