### PR TITLE
quickstart: Remove uses of LogPrinter

### DIFF
--- a/coala_quickstart/coala_quickstart.py
+++ b/coala_quickstart/coala_quickstart.py
@@ -5,8 +5,6 @@ import sys
 
 from pyprint.ConsolePrinter import ConsolePrinter
 
-from coalib.output.printers.LogPrinter import LogPrinter
-
 from coala_utils.FilePathCompleter import FilePathCompleter
 from coala_utils.Question import ask_question
 
@@ -65,7 +63,7 @@ def main():
 
     logging.basicConfig(stream=sys.stdout)
     printer = ConsolePrinter()
-    log_printer = LogPrinter(printer)
+    logging.getLogger(__name__)
 
     fpc = None
     project_dir = os.getcwd()
@@ -81,7 +79,7 @@ def main():
         fpc.deactivate()
 
     project_files, ignore_globs = get_project_files(
-        log_printer,
+        None,
         printer,
         project_dir,
         fpc,

--- a/coala_quickstart/generation/Bears.py
+++ b/coala_quickstart/generation/Bears.py
@@ -3,7 +3,6 @@ import random
 import re
 from collections import defaultdict
 
-from pyprint.NullPrinter import NullPrinter
 
 from coala_quickstart.Constants import (
     IMPORTANT_BEAR_LIST, ALL_CAPABILITIES, DEFAULT_CAPABILTIES)
@@ -12,13 +11,13 @@ from coala_quickstart.generation.SettingsFilling import is_autofill_possible
 from coalib.bearlib.abstractions.LinterClass import LinterClass
 from coalib.settings.ConfigurationGathering import get_filtered_bears
 from coalib.misc.DictUtilities import inverse_dicts
-from coalib.output.printers.LogPrinter import LogPrinter
 
 
 def filter_relevant_bears(used_languages,
                           printer,
                           arg_parser,
-                          extracted_info):
+                          extracted_info,
+                          log_printer=None):
     """
     From the bear dict, filter the bears per relevant language.
 
@@ -37,7 +36,6 @@ def filter_relevant_bears(used_languages,
         A dict with language name as key and bear classes as value.
     """
     args = arg_parser.parse_args() if arg_parser else None
-    log_printer = LogPrinter(NullPrinter())
     used_languages.append(("All", 100))
 
     bears_by_lang = {

--- a/coala_quickstart/generation/Settings.py
+++ b/coala_quickstart/generation/Settings.py
@@ -2,12 +2,9 @@ import os
 from collections import OrderedDict
 from datetime import date
 
-from pyprint.NullPrinter import NullPrinter
-from pyprint.ConsolePrinter import ConsolePrinter
 from coalib.settings.SectionFilling import fill_settings
 from coala_quickstart.generation.SettingsFilling import (
     fill_section, acquire_settings)
-from coalib.output.printers.LogPrinter import LogPrinter
 from coala_quickstart.generation.Utilities import (
     split_by_language, get_extensions)
 from coalib.settings.Section import Section
@@ -36,7 +33,11 @@ def generate_section(section_name, extensions_used, bears):
     return section
 
 
-def generate_ignore_field(project_dir, languages, extset, ignore_globs):
+def generate_ignore_field(project_dir,
+                          languages,
+                          extset,
+                          ignore_globs,
+                          null_printer=None):
     """
     Generate the ignore field for the ``default`` section.
 
@@ -50,7 +51,6 @@ def generate_ignore_field(project_dir, languages, extset, ignore_globs):
     :return:
         A comma-separated string containing the globs to ignore.
     """
-    null_printer = LogPrinter(NullPrinter())
 
     all_files = set(collect_files(
         "**",
@@ -67,8 +67,13 @@ def generate_ignore_field(project_dir, languages, extset, ignore_globs):
     return ", ".join(ignores)
 
 
-def generate_settings(project_dir, project_files, ignore_globs, relevant_bears,
-                      extracted_info, incomplete_sections=False):
+def generate_settings(project_dir,
+                      project_files,
+                      ignore_globs,
+                      relevant_bears,
+                      extracted_info,
+                      incomplete_sections=False,
+                      log_printer=None):
     """
     Generates the settings for the given project.
 
@@ -120,8 +125,6 @@ def generate_settings(project_dir, project_files, ignore_globs, relevant_bears,
                 "all." + lang,
                 extset[lang],
                 relevant_bears[lang_map[lang]])
-
-    log_printer = LogPrinter(ConsolePrinter())
 
     if not incomplete_sections:
         fill_settings(settings,

--- a/tests/generation/Bears.py
+++ b/tests/generation/Bears.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 
 
 from pyprint.ConsolePrinter import ConsolePrinter
-from coalib.output.printers.LogPrinter import LogPrinter
 from coala_utils.ContextManagers import (
     retrieve_stdout, simulate_console_inputs)
 from coala_quickstart.generation.Bears import (
@@ -114,7 +113,7 @@ class TestBears(unittest.TestCase):
         os.makedirs(self.project_dir, exist_ok=True)
         self.arg_parser = _get_arg_parser()
         self.printer = ConsolePrinter()
-        self.log_printer = LogPrinter(self.printer)
+        self.log_printer = None
         self.old_argv = deepcopy(sys.argv)
         del sys.argv[1:]
 

--- a/tests/generation/FileGlobs.py
+++ b/tests/generation/FileGlobs.py
@@ -2,7 +2,6 @@ import os
 import unittest
 
 from pyprint.ConsolePrinter import ConsolePrinter
-from coalib.output.printers.LogPrinter import LogPrinter
 from coala_utils.ContextManagers import (
     simulate_console_inputs, suppress_stdout)
 from coala_utils.FilePathCompleter import FilePathCompleter
@@ -15,7 +14,7 @@ class TestQuestion(unittest.TestCase):
 
     def setUp(self):
         self.printer = ConsolePrinter()
-        self.log_printer = LogPrinter(self.printer)
+        self.log_printer = None
         self.file_path_completer = FilePathCompleter()
 
     def test_get_project_files(self):

--- a/tests/generation/SettingsFillingTest.py
+++ b/tests/generation/SettingsFillingTest.py
@@ -1,13 +1,11 @@
 import os
 import unittest
 
-from pyprint.ConsolePrinter import ConsolePrinter
 
 from coalib.bears.GlobalBear import GlobalBear
 from coalib.bears.LocalBear import LocalBear
 from coala_utils.ContextManagers import (
     simulate_console_inputs, retrieve_stdout)
-from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 from coalib.settings.SectionFilling import fill_settings
@@ -78,7 +76,7 @@ class SettingsFillingTest(unittest.TestCase):
 
     def setUp(self):
         self.project_dir = os.path.dirname(os.path.realpath(__file__))
-        self.log_printer = LogPrinter(ConsolePrinter())
+        self.log_printer = None
         self.section = Section('test')
         self.section.append(Setting('key', 'val'))
 


### PR DESCRIPTION
This removes every use of LogPrinter.
Also, it replaces use of LogPrinter into
logging.getLogger() or None.

Closes https://github.com/coala/coala-quickstart/issues/158