### PR TITLE
.gitignore: add .DS_Store to .gitignore .DS_Store files should be add…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Goopfile.lock
 docs/API/
 venv
 *.egg-info
+.DS_Store


### PR DESCRIPTION
…ed to .gitignore as they don’t contain any relevant information and users have to add this setting repeatedly to their local repositories. Fixes https://github.com/coala/coala-quickstart/issues/198