### PR TITLE
requirements.txt: Unpin lxml version

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -15,6 +15,13 @@ environment:
       PYTHON_VERSION: "3.4.4"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
 cache:
   - "C:\\pip_cache"
   - "node_modules"

--- a/.moban.yaml
+++ b/.moban.yaml
@@ -9,7 +9,6 @@ build_version: 0.4.0
 package_module: coala_quickstart
 url: https://github.com/coala/coala-quickstart
 docs_dir: false
-test_py36: false
 test_timeout: 60
 
 maintainers: false
@@ -29,8 +28,6 @@ entry_points:
     - coala-quickstart = coala_quickstart.coala_quickstart:main
 
 dependencies:
-  # TODO: Remove lxml once the upstream issue https://github.com/vfaronov/httpolice/issues/5 with HTTpolice is fixed.
-  - lxml==3.6.0
   - coala_bears~=0.12.0.dev20170722110839
   - coala_utils~=0.6.6
   - gemfileparser~=0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-lxml==3.6.0
 coala_bears~=0.12.0.dev20170722110839
 coala_utils~=0.6.6
 gemfileparser~=0.6.2


### PR DESCRIPTION
The upstream issue https://bugs.launchpad.net/lxml/+bug/1704707
with lxml regarding missing wheel on Winows is fixed now.

Related to https://github.com/coala/coala-quickstart/issues/166