### PR TITLE
.coafile: Fix ignore files field not getting created     

### DIFF
--- a/coala_quickstart/generation/FileGlobs.py
+++ b/coala_quickstart/generation/FileGlobs.py
@@ -1,4 +1,5 @@
 import os
+import itertools
 
 from coalib.parsing.Globbing import glob_escape
 from coala_quickstart.generation.Utilities import get_gitignore_glob
@@ -34,7 +35,9 @@ def get_project_files(log_printer,
         printer.print("The contents of your .gitignore file for the project "
                       "will be automatically loaded as the files to ignore.",
                       color="green")
-        ignore_globs = get_gitignore_glob(project_dir)
+        ignore_globs, ignore_globs_backup = itertools.tee(
+            get_gitignore_glob(project_dir))
+
     if non_interactive and not ignore_globs:
         ignore_globs = []
 
@@ -46,6 +49,7 @@ def get_project_files(log_printer,
             "project directory?",
             printer=printer,
             typecast=list)
+        ignore_globs, ignore_globs_backup = itertools.tee(ignore_globs)
         file_path_completer.deactivate()
     printer.print()
 
@@ -53,7 +57,7 @@ def get_project_files(log_printer,
     file_path_globs = [os.path.join(
         escaped_project_dir, glob_exp) for glob_exp in file_globs]
     ignore_path_globs = [os.path.join(
-        escaped_project_dir, glob_exp) for glob_exp in ignore_globs]
+        escaped_project_dir, glob_exp) for glob_exp in ignore_globs_backup]
 
     ignore_path_globs.append(os.path.join(escaped_project_dir, ".git/**"))
 

--- a/coala_quickstart/generation/Settings.py
+++ b/coala_quickstart/generation/Settings.py
@@ -1,4 +1,5 @@
 import os
+import itertools
 from collections import OrderedDict
 from datetime import date
 
@@ -48,20 +49,24 @@ def generate_ignore_field(project_dir,
     :param extset:
         A dict with language name as key and a set of extensions as
         value. This includes only those extensions used by the project.
+    :ignore_globs:
+        generator object get_gitignore_glob
     :return:
         A comma-separated string containing the globs to ignore.
     """
 
+    ignore_globs, ignore_globs_backup = itertools.tee(ignore_globs)
+
     all_files = set(collect_files(
         "**",
         null_printer,
-        ignored_file_paths=ignore_globs))
+        ignored_file_paths=ignore_globs_backup))
 
     ignores = []
     for glob in ignore_globs:
         gitignore_files = {file
                            for file in collect_files([glob], null_printer)}
-        if not all_files.isdisjoint(gitignore_files):
+        if all_files.isdisjoint(gitignore_files):
             ignores.append(os.path.relpath(glob, project_dir))
 
     return ", ".join(ignores)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 norecursedirs =
     .git
     dist


### PR DESCRIPTION
FileGlobs.py & Settings.py: duplicate the iterator ignore_globs as it gets exhausted
Settings.py: all_files was already disjoint from ignore_globs
    
Closes https://github.com/coala/coala-quickstart/issues/173
Closes https://github.com/coala/coala-quickstart/issues/157