### PR TITLE
.coafile: Fix ignore files field not created

### DIFF
--- a/coala_quickstart/generation/FileGlobs.py
+++ b/coala_quickstart/generation/FileGlobs.py
@@ -49,6 +49,7 @@ def get_project_files(log_printer,
         file_path_completer.deactivate()
     printer.print()
 
+    ignore_globs = list(ignore_globs)
     escaped_project_dir = glob_escape(project_dir)
     file_path_globs = [os.path.join(
         escaped_project_dir, glob_exp) for glob_exp in file_globs]

--- a/coala_quickstart/generation/Settings.py
+++ b/coala_quickstart/generation/Settings.py
@@ -61,8 +61,7 @@ def generate_ignore_field(project_dir,
     for glob in ignore_globs:
         gitignore_files = {file
                            for file in collect_files([glob], null_printer)}
-        if not all_files.isdisjoint(gitignore_files):
-            ignores.append(os.path.relpath(glob, project_dir))
+        ignores.append(os.path.relpath(glob, project_dir))
 
     return ", ".join(ignores)
 


### PR DESCRIPTION
duplicate the generator ignore_globs as it was getting exhausted, all_files was already disjoint from ignore_globs, corrected condition

1.)  `ignore` globs is a `generator object`. If you iterate through it once, it gets exhausted. I found 2 instances where the same exhausted object was being used to iterate through over again i.e. the second time it wasn't going inside the loop, so what I did was duplicated that generator object using `itertools.tee()` and for one iteration send `ignore_globs_backup` and for the second used `ignore_globs`

2.)  This condition https://github.com/coala/coala-quickstart/blob/50b358a60454932c0c33fe9443f305abd1103b11/coala_quickstart/generation/Settings.py#L64 will always be false because of the line https://github.com/coala/coala-quickstart/blob/50b358a60454932c0c33fe9443f305abd1103b11/coala_quickstart/generation/Settings.py#L58 NOTE: while setting the value of `all_files`, `ignore_globs` is passed to the `collect_files` function. The `not` had to be removed from this condition, but it was decreasing code coverage.

3.)  I wrote an extra test case to increase code coverage since there wasn't any test case which was actually passing any thing to `ignore_globs`

Closes #157