### PR TITLE
Implement BearSettings class for type of settings

### DIFF
--- a/coala_quickstart/coala_quickstart.py
+++ b/coala_quickstart/coala_quickstart.py
@@ -21,6 +21,8 @@ from coala_quickstart.generation.Bears import (
 )
 from coala_quickstart.generation.Settings import (
     generate_settings, write_coafile)
+from coala_quickstart.generation.SettingsClass import (
+    collect_bear_settings)
 
 
 def _get_arg_parser():
@@ -54,6 +56,12 @@ coala-quickstart automatically creates a .coafile for use by coala.
         dest='no_filter_by_capabilities', const=True,
         help='disable filtering of bears by their capabilties.')
 
+    arg_parser.add_argument(
+        '-g', '--green-mode', const=True, action='store_const',
+        help='Produce "green" config files for you project. Green config files'
+             'don\'t generate any error in the project and match the coala'
+             'configuration as closely as possible to your project.')
+
     return arg_parser
 
 
@@ -68,7 +76,12 @@ def main():
     fpc = None
     project_dir = os.getcwd()
 
-    if not args.non_interactive:
+    if args.green_mode:
+        args.non_interactive = None
+        args.no_filter_by_capabilities = None
+        args.incomplete_sections = None
+
+    if not args.non_interactive and not args.green_mode:
         fpc = FilePathCompleter()
         fpc.activate()
         print_welcome_message(printer)
@@ -92,6 +105,9 @@ def main():
 
     relevant_bears = filter_relevant_bears(
         used_languages, printer, arg_parser, extracted_information)
+
+    if args.green_mode:
+        collect_bear_settings(relevant_bears)
 
     print_relevant_bears(printer, relevant_bears)
 

--- a/coala_quickstart/generation/Bears.py
+++ b/coala_quickstart/generation/Bears.py
@@ -57,6 +57,9 @@ def filter_relevant_bears(used_languages,
     candidate_bears = copy.copy(bears_by_lang)
     to_propose_bears = {}
 
+    if args.green_mode:
+        return candidate_bears
+
     # Initialize selected_bears with IMPORTANT_BEAR_LIST
     for lang, lang_bears in candidate_bears.items():
         if lang_bears and lang in IMPORTANT_BEAR_LIST:

--- a/coala_quickstart/generation/SettingsClass.py
+++ b/coala_quickstart/generation/SettingsClass.py
@@ -1,0 +1,260 @@
+from coala_quickstart.generation.Utilities import (
+    search_for_orig, get_all_args, get_default_args)
+
+
+def in_annot(func, key):
+    """
+    Checks if a setting name as key is present in function
+    annotations.
+    :param func:
+        Function object.
+    :param key:
+        The setting name as a string.
+    :return:
+        The value of type annotated or False.
+    """
+    return func.__annotations__[key] if key in func.__annotations__ else False
+
+
+def in_default_args(func, key):
+    """
+    Checks if a setting name as key is present in function
+    arguments with default value.
+    :param func:
+        Function object.
+    :param key:
+        The setting name as a string.
+    :return:
+        True if key is present in args with default value else False.
+    """
+    return True if key in get_default_args(func) else False
+
+
+def in_all_args(func, key):
+    """
+    Checks if a setting name as key is present in function
+    arguments.
+    :param func:
+        Function object.
+    :param key:
+        The setting name as a string.
+    :return:
+        True if key is present in args of a function else False.
+    """
+    return True if key in get_all_args(func) else False
+
+
+class SettingTypes:
+
+    """
+    Categorizes the settings into Type bool and Type others
+    """
+
+    def __init__(self, settings, function, function_name, bear, trigger):
+        """
+        :param settings:
+            Either a dict of non-optional settings of the form:
+            {'setting_name': ('Description.', <class 'type'>),}
+            or
+            a dict of optional settings of the form:
+            {'setting_name': default_values,}
+        :param function:
+            The function object i.e. either the run() method or
+            the create_arguments() method of the bear.
+        :param function_name:
+            Name of the function, either 'run' or 'create_arguments'
+        :param bear:
+            The current bear object.
+        :param trigger:
+            String of value either 'optional' or 'non-optional'
+            depending on type of settings
+        """
+        self.settings_bool = []
+        self.settings_others = []
+        self.fillup_settings(function, settings, bear, trigger)
+
+    def fillup_settings(self, function, settings, bear, trigger):
+        """
+        Fill settings_bool and settings_others depending upon whether the
+        particular setting by the bear takes a bool value or any other.
+        :param function:
+            The function object i.e. either the run() method or
+            the create_arguments() method of the bear.
+        :param settings:
+            Either a dict of non-optional settings of the form:
+            {'setting_name': ('Description.', <class 'type'>),}
+            or
+            a dict of optional settings of the form:
+            {'setting_name': default_values,}
+        :param bear:
+            The current bear object.
+        :param trigger:
+            String of value either 'optional' or 'non-optional'
+            depending on type of settings
+        """
+        for key in settings:
+            if trigger == 'optional':
+                self.fillup_optional_settings(key, function)
+            elif trigger == 'non-optional':
+                self.fillup_non_optional_settings(key, function, bear)
+            else:
+                raise ValueError('Invalid trigger Type')
+
+    def fillup_optional_settings(self, key, func):
+        """
+        Function to populate the optional settings
+        for the classes to store metadata.
+        :param key:
+            The setting value as a string.
+        :param func:
+            The function object. Either create_arguments() for linter bears
+            or run() for other bears.
+        """
+        present_in_annot = in_annot(func, key)
+
+        if present_in_annot:
+            self.diff_bool_others(key, present_in_annot)
+        else:
+            self.diff_bool_others_default(key, get_default_args(func)[key])
+
+    def fillup_non_optional_settings(self, key, func, bear):
+        """
+        Function to populate the non-optional settings
+        for the classes to store metadata.
+        :param key:
+            The setting value as a string.
+        :param func:
+            The function object. Either create_arguments() for linter bears
+            or run() for other bears.
+        :param bear:
+            The bear object.
+        """
+        present_in_annot = in_annot(func, key)
+        present_in_default_args = in_default_args(func, key)
+        present_in_all_args = in_all_args(func, key)
+
+        if present_in_annot:
+            self.diff_bool_others(key, present_in_annot)
+        elif present_in_all_args and not present_in_default_args:
+            self.diff_bool_others(key, get_all_args(func)[key])
+        else:
+            self.parse_dep_tree(bear, key)
+
+    def parse_dep_tree(self, bear, key):
+        """
+        Parses the bear's dependency tree looking for
+        non-optional setting and their Type.
+        :param bear:
+            The bear object.
+        :param key:
+            The setting value as a string.
+        """
+        deps = bear.BEAR_DEPS
+        for dep in deps:
+            present_in_annot = in_annot(dep.run, key)
+            if present_in_annot:
+                self.diff_bool_others(key, present_in_annot)
+            else:
+                settings = get_all_args(dep.run)
+                for pointer in get_default_args(dep.run):
+                    del settings[pointer]
+                if key in settings:
+                    self.diff_bool_others(key, settings[key])
+            self.parse_dep_tree(dep, key)
+
+    def diff_bool_others(self, key, check):
+        """
+        Checks if a settings is of Type bool or any other based
+        on the value of check and feeds
+        up the classes to store metadata in the list variables,
+        SettingTypes.setting_bool and SettingTypes.setting_others.
+        :param key:
+            The Setting value as a string.
+        :param check:
+            The Type to which the key is to be checked against.
+        """
+
+        if check == bool:
+            self.settings_bool.append(key)
+        else:
+            self.settings_others.append(key)
+
+    def diff_bool_others_default(self, key, check):
+        """
+        Checks if a settings is of Type bool or any other based
+        on the value of check and feeds
+        up the metaclass.
+        :param key:
+            The Setting value as a string.
+        :param check:
+            The Type to which the key is to be checked against.
+        """
+        if isinstance(check, bool):
+            self.settings_bool.append(key)
+        else:
+            self.settings_others.append(key)
+
+
+class BearSettings:
+
+    """
+    Collect optional and non-optional settings for each bear
+    """
+
+    def __init__(self, bear):
+        """
+        :param bear:
+            A bear class object.
+        """
+        self.bear = bear
+        function = bear.create_arguments if (
+            'create_arguments' in dir(bear)) else bear.run
+        function_name = 'create_arguments' if (
+            'create_arguments' in dir(bear)) else 'run'
+        non_optional_settings = bear.get_non_optional_settings()
+
+        # Get the actual function if the function is decorated.
+        original_function = search_for_orig(function, function_name)
+        if original_function is not None:
+            function = original_function
+
+        optional_settings = get_default_args(function)
+        self.create_setting_types_obj(optional_settings, non_optional_settings,
+                                      function, function_name, bear)
+
+    def create_setting_types_obj(self, optional_settings,
+                                 non_optional_settings, function,
+                                 function_name, bear):
+        """
+        :param optional_settings:
+            A dict of optional settings for the bear.
+        :param non_optional_settings:
+            A dict of non-optional settings for the bear.
+        :param function:
+            The function object i.e. either the run() method or
+            the create_arguments() method of the bear.
+        :param function_name:
+            Name of the function, either 'run' or 'create_arguments'
+        :param bear:
+            The current bear object.
+        """
+        self.non_optional_settings = SettingTypes(
+            non_optional_settings, function, function_name, bear,
+            trigger='non-optional')
+        self.optional_settings = SettingTypes(
+            optional_settings, function, function_name, bear,
+            trigger='optional')
+
+
+def collect_bear_settings(bears):
+    """
+    :param bears:
+        Dict of candidate bears for the project for each language.
+    :return:
+        A BearSettings object.
+    """
+    bear_settings_obj = []
+    for language in bears:
+        for bear in bears[language]:
+            bear_settings_obj.append(BearSettings(bear))
+    return bear_settings_obj

--- a/coala_quickstart/generation/Utilities.py
+++ b/coala_quickstart/generation/Utilities.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 from collections import defaultdict
 
@@ -111,3 +112,52 @@ def get_extensions(project_files):
                 extset[lang.lower()].add(ext)
 
     return extset
+
+
+def get_default_args(func):
+    """
+    :param func: Function name.
+    :return:
+        A dict of function paramters as keys
+        and default values as value if default values exist.
+    """
+    signature = inspect.signature(func)
+    return {
+        k: v.default
+        for k, v in signature.parameters.items()
+        if v.default is not inspect.Parameter.empty
+    }
+
+
+def get_all_args(func):
+    """
+    :param func: Function name.
+    :return:
+        A dict of function paramters as keys
+        and default values as value.
+    """
+    signature = inspect.signature(func)
+    return {
+        k: v.default
+        for k, v in signature.parameters.items()
+    }
+
+
+def search_for_orig(decorated, orig_name):
+    """
+    Extracts out the original function if the function is decorated with
+    one or more decorators.
+    :param decorated:
+        The decorated function object.
+    :param orig_name:
+        The name of the original function.
+    :return:
+        None or the original function object.
+    """
+    if decorated.__closure__ is not None:
+        for obj in (c.cell_contents for c in decorated.__closure__):
+            if hasattr(obj, '__name__') and obj.__name__ == orig_name:
+                return obj
+            if hasattr(obj, '__closure__') and obj.__closure__:
+                found = search_for_orig(obj, orig_name)
+                return found

--- a/tests/generation/Bears.py
+++ b/tests/generation/Bears.py
@@ -14,6 +14,7 @@ from coala_quickstart.coala_quickstart import _get_arg_parser
 from coala_quickstart.Constants import (
     IMPORTANT_BEAR_LIST, ALL_CAPABILITIES)
 from coala_quickstart.generation.InfoCollector import collect_info
+from coalib.collecting.Collectors import get_all_bears
 from tests.TestUtilities import bear_test_module, generate_files
 
 
@@ -129,6 +130,23 @@ class TestBears(unittest.TestCase):
         self.assertIn("Python", res)
         self.assertTrue(len(res["C"]) > 0)
         self.assertTrue(len(res["Python"]) > 0)
+
+    def test_filter_relevant_bears_green_mode(self):
+        from argparse import Namespace
+        invalid_bears = ['DocGrammarBear', 'DocumentationStyleBear']
+        self.arg_parser.parse_args = unittest.mock.MagicMock(
+            return_value=Namespace(green_mode=True))
+        res = filter_relevant_bears([('Python', 70), ('C', 20)],
+                                    self.printer,
+                                    self.arg_parser,
+                                    {})
+        for lang in res:
+            result = list(filter(lambda x: next((
+                False for bear in invalid_bears if bear in str(x)), True),
+                                 list(res[lang])))
+            to_compare = list(filter(lambda x: lang in x.LANGUAGES,
+                                     get_all_bears()))
+            self.assertCountEqual(result, to_compare)
 
     def test_filter_relevant_bears_with_extracted_info(self):
         # results without extracted information

--- a/tests/generation/SettingsClassTest.py
+++ b/tests/generation/SettingsClassTest.py
@@ -1,0 +1,124 @@
+import unittest
+
+from pyprint.ConsolePrinter import ConsolePrinter
+from coala_quickstart.generation.SettingsClass import (
+    collect_bear_settings, BearSettings, SettingTypes)
+from tests.test_bears.AllKindsOfSettingsDependentBear import (
+    AllKindsOfSettingsDependentBear)
+from tests.test_bears.AllKindsOfSettingsDependentDecoratedBear import (
+    AllKindsOfSettingsDependentDecoratedBear)
+from tests.test_bears.AllKindsOfSettingsBaseBear import (
+    AllKindsOfSettingsBaseBear)
+from tests.test_bears.BearA import BearA
+
+
+class TestSettingsClass(unittest.TestCase):
+
+    def setUp(self):
+        self.printer = ConsolePrinter()
+        self.log_printer = None
+
+    def test_collect_bear_settings(self):
+        relevant_bears = {'test':
+                          {AllKindsOfSettingsDependentBear,
+                           AllKindsOfSettingsDependentDecoratedBear,
+                           AllKindsOfSettingsBaseBear,
+                           BearA}}
+
+        bear_settings_obj = collect_bear_settings(relevant_bears)
+
+        # The following test is for testing out the sorting of settings
+        # into Type bool and other Types using the test bear
+        # AllKindsOfSettingsDependentBear. This bear has all kinds of
+        # possible setting types and is dependent on another similar
+        # kind of bear so that the non-optional settings from the
+        # base bear also show up here.
+
+        k = 0
+        for index, i in enumerate(bear_settings_obj):
+            if i.bear == AllKindsOfSettingsDependentBear:
+                k = index
+                break
+        obj = bear_settings_obj[k].non_optional_settings
+        self.assertCountEqual(obj.settings_bool, ['use_bear', 'use_bears'])
+        self.assertCountEqual(obj.settings_others, ['config',
+                                                    'max_line_lengths',
+                                                    'no_line', 'configs',
+                                                    'no_lines'])
+        obj = bear_settings_obj[k].optional_settings
+        self.assertCountEqual(obj.settings_bool, ['use_spaces', 'use_tabs',
+                                                  'chars'])
+        self.assertCountEqual(obj.settings_others, ['max_line_lengths',
+                                                    'no_chars',
+                                                    'dependency_results'])
+
+        # The following test is for testing out the sorting of settings
+        # into Type bool and other Types using the test bear
+        # AllKindsOfSettingsDependentDecoratedBear. This bear has all kinds of
+        # possible setting types and is dependent on another similar
+        # kind of bear so that the non-optional settings from the
+        # base bear also show up here. Moreover the run methods of both these
+        # bears are decorated to test out whether the code is able to extract
+        # out the original function from the decorated methods and provide
+        # us with the correct bear settings.
+
+        for index, i in enumerate(bear_settings_obj):
+            if i.bear == AllKindsOfSettingsDependentDecoratedBear:
+                k = index
+                break
+        obj = bear_settings_obj[k].non_optional_settings
+        self.assertCountEqual(obj.settings_bool, ['use_bear', 'use_bears'])
+        self.assertCountEqual(obj.settings_others, ['config',
+                                                    'max_line_lengths',
+                                                    'no_line',
+                                                    'configs',
+                                                    'no_lines'])
+        obj = bear_settings_obj[k].optional_settings
+        self.assertCountEqual(obj.settings_bool, ['use_spaces', 'use_tabs',
+                                                  'chars'])
+        self.assertCountEqual(obj.settings_others, ['max_line_lengths',
+                                                    'no_chars',
+                                                    'dependency_results'])
+
+        # The following test is for testing out the sorting of settings
+        # into Type bool and other Types using the test bear
+        # AllKindsOfSettingsBaseBear. This bear has all kinds of
+        # possible setting types.
+
+        for index, i in enumerate(bear_settings_obj):
+            if i.bear == AllKindsOfSettingsBaseBear:
+                k = index
+                break
+        obj = bear_settings_obj[k].non_optional_settings
+        self.assertCountEqual(obj.settings_bool, ['use_bear'])
+        self.assertCountEqual(obj.settings_others, ['config',
+                                                    'max_line_lengths',
+                                                    'no_line'])
+        obj = bear_settings_obj[k].optional_settings
+        self.assertCountEqual(obj.settings_bool, ['use_space', 'use_tab'])
+        self.assertCountEqual(obj.settings_others, ['max_line_length',
+                                                    'no_char',
+                                                    'dependency_result'])
+
+        # The following test is for testing out the sorting of settings
+        # into Type bool and other Types using the test bear
+        # BearA. This bear is dependent on BearB which is further dependent
+        # on BearC to test out that non-optional settings from BearC
+        # are appearring over here and the parsing of the bear dependency
+        # tree is done right.
+
+        for index, i in enumerate(bear_settings_obj):
+            if i.bear == BearA:
+                k = index
+                break
+        obj = bear_settings_obj[k].non_optional_settings
+        self.assertCountEqual(obj.settings_bool, ['use_spaces'])
+        self.assertCountEqual(obj.settings_others, [])
+        obj = bear_settings_obj[k].optional_settings
+        self.assertCountEqual(obj.settings_bool, [])
+        self.assertCountEqual(obj.settings_others, [])
+
+    def test_invalid_trigger(self):
+        with self.assertRaises(ValueError, msg='Invalid trigger Type'):
+            setting = SettingTypes({'a': bool}, None, '', None,
+                                   'wubalubadubdub')

--- a/tests/generation/UtilitiesTest.py
+++ b/tests/generation/UtilitiesTest.py
@@ -1,0 +1,69 @@
+import inspect
+import types
+import unittest
+
+from tests.test_bears.AllKindsOfSettingsDependentBear import (
+    AllKindsOfSettingsDependentBear)
+from coala_quickstart.generation.Utilities import (
+    get_default_args, get_all_args,
+    search_for_orig)
+
+
+def foo():
+    pass
+
+
+def foo_bar(n):
+    def bar():
+        return n+1
+    return bar
+
+
+class TestAdditionalFunctions(unittest.TestCase):
+
+    def second(func):
+        def wrapper():
+            return func()
+        return wrapper
+
+    def first():
+        pass
+
+    third = second(first)
+    fourth = second(second(first))
+
+    def test_search_for_orig(self):
+        self.assertEqual(types.MethodType(search_for_orig(self.third, 'first'),
+                                          self), self.first)
+        self.assertEqual(types.MethodType(search_for_orig(self.fourth,
+                                                          'first'),
+                                          self), self.first)
+        self.assertEqual(search_for_orig(self.first, 'first'), None)
+        self.assertEqual(search_for_orig(self.first, "bar"), None)
+        self.assertEqual(search_for_orig(self.first, "first"), None)
+        # function without closure
+        self.assertEqual(search_for_orig(foo, "bar"), None)
+        self.assertEqual(search_for_orig(foo, "foo"), None)
+        func = foo_bar(3)
+        x = func()  # function with closure
+        self.assertEqual(search_for_orig(func, "bar"), None)
+
+    def test_get_default_args(self):
+        self.assertEqual(get_default_args(AllKindsOfSettingsDependentBear.run),
+                         {'chars': False,
+                          'dependency_results': {},
+                          'max_line_lengths': 1000,
+                          'no_chars': 79,
+                          'use_spaces': None,
+                          'use_tabs': False})
+
+    def test_get_all_args(self):
+        empty = inspect._empty
+        self.assertEqual(get_all_args(AllKindsOfSettingsDependentBear.run),
+                         {'self': empty, 'file': empty, 'filename': empty,
+                          'configs': empty,
+                          'use_bears': empty, 'no_lines': empty,
+                          'use_spaces': None,
+                          'use_tabs': False, 'max_line_lengths': 1000,
+                          'no_chars': 79,
+                          'chars': False, 'dependency_results': {}})

--- a/tests/test_bears/AllKindsOfSettingsBaseBear.py
+++ b/tests/test_bears/AllKindsOfSettingsBaseBear.py
@@ -1,0 +1,10 @@
+from coalib.bears.LocalBear import LocalBear
+
+
+class AllKindsOfSettingsBaseBear(LocalBear):
+
+    def run(self, file, filename, config, use_bear: bool,
+            max_line_lengths, no_line: int, use_space: bool = None,
+            use_tab: bool = False, max_line_length: int = 1000,
+            no_char=79, dependency_result=dict()):
+        pass

--- a/tests/test_bears/AllKindsOfSettingsBaseDecoratedBear.py
+++ b/tests/test_bears/AllKindsOfSettingsBaseDecoratedBear.py
@@ -1,0 +1,12 @@
+from coalib.bears.LocalBear import LocalBear
+from coalib.bearlib import deprecate_settings
+
+
+class AllKindsOfSettingsBaseDecoratedBear(LocalBear):
+
+    @deprecate_settings(max_line_lengths='tab_width')
+    def run(self, file, filename, config, use_bear: bool,
+            max_line_lengths, no_line: int, use_space: bool = None,
+            use_tab: bool = False, max_line_length: int = 1000,
+            no_char=79, dependency_result=dict()):
+        pass

--- a/tests/test_bears/AllKindsOfSettingsDependentBear.py
+++ b/tests/test_bears/AllKindsOfSettingsDependentBear.py
@@ -1,0 +1,13 @@
+from coalib.bears.LocalBear import LocalBear
+from tests.test_bears.AllKindsOfSettingsBaseBear import \
+    AllKindsOfSettingsBaseBear
+
+
+class AllKindsOfSettingsDependentBear(LocalBear):
+    BEAR_DEPS = {AllKindsOfSettingsBaseBear}
+
+    def run(self, file, filename, configs, use_bears: bool,
+            no_lines: int, use_spaces: bool = None,
+            use_tabs: bool = False, max_line_lengths: int = 1000,
+            no_chars=79, chars=False, dependency_results=dict()):
+        pass

--- a/tests/test_bears/AllKindsOfSettingsDependentDecoratedBear.py
+++ b/tests/test_bears/AllKindsOfSettingsDependentDecoratedBear.py
@@ -1,0 +1,15 @@
+from coalib.bears.LocalBear import LocalBear
+from coalib.bearlib import deprecate_settings
+from tests.test_bears.AllKindsOfSettingsBaseDecoratedBear import \
+    AllKindsOfSettingsBaseDecoratedBear
+
+
+class AllKindsOfSettingsDependentDecoratedBear(LocalBear):
+    BEAR_DEPS = {AllKindsOfSettingsBaseDecoratedBear}
+
+    @deprecate_settings(max_line_lengths='tab_width')
+    def run(self, file, filename, configs, use_bears: bool,
+            no_lines: int, use_spaces: bool = None,
+            use_tabs: bool = False, max_line_lengths: int = 1000,
+            no_chars=79, chars=False, dependency_results=dict()):
+        pass

--- a/tests/test_bears/BearA.py
+++ b/tests/test_bears/BearA.py
@@ -1,0 +1,9 @@
+from coalib.bears.LocalBear import LocalBear
+from tests.test_bears.BearB import BearB
+
+
+class BearA(LocalBear):
+    BEAR_DEPS = {BearB}
+
+    def run():
+        pass

--- a/tests/test_bears/BearB.py
+++ b/tests/test_bears/BearB.py
@@ -1,0 +1,9 @@
+from coalib.bears.LocalBear import LocalBear
+from tests.test_bears.BearC import BearC
+
+
+class BearB(LocalBear):
+    BEAR_DEPS = {BearC}
+
+    def run():
+        pass

--- a/tests/test_bears/BearC.py
+++ b/tests/test_bears/BearC.py
@@ -1,0 +1,6 @@
+from coalib.bears.LocalBear import LocalBear
+
+
+class BearC(LocalBear):
+    def run(use_spaces: bool):
+        pass


### PR DESCRIPTION
* SettingsClass.py: Add function `get_all_args`, get_default_args`,
  `search_for_orig`, implement classes `BearSettings` and
  `SettingTypes`, add function `collect_bear_settings`.
* coala_quickstart.py: Add the tag for --green-mode, disable all
  other modes if green mode is activated and call
  `collect_bear_settings` to get the metadata of types of bear
  settings.
* Bears.py: Return all candidate bears if green mode is activated.

Closes https://github.com/coala/coala-quickstart/issues/241