### PR TITLE
Fix a typo

### DIFF
--- a/coala_quickstart/generation/Bears.py
+++ b/coala_quickstart/generation/Bears.py
@@ -153,7 +153,7 @@ def filter_relevant_bears(used_languages,
         filtered_bears = remove_bears_with_conflicting_capabilties(
             filtered_bears)
 
-        # Add to the selectecd_bears
+        # Add to the selected_bears
         for lang, lang_bears in filtered_bears.items():
             if not selected_bears.get(lang):
                 selected_bears[lang] = lang_bears


### PR DESCRIPTION
This fixes the typo and changes
it from selectecd_bears --> selected_bears.

Fixes https://github.com/coala/coala-quickstart/issues/240