### PR TITLE
Settings.py: Unused variables removed

### DIFF
--- a/coala_quickstart/generation/Settings.py
+++ b/coala_quickstart/generation/Settings.py
@@ -9,7 +9,6 @@ from coala_quickstart.generation.Utilities import (
     split_by_language, get_extensions)
 from coalib.settings.Section import Section
 from coalib.output.ConfWriter import ConfWriter
-from coalib.collecting.Collectors import collect_files
 
 
 def generate_section(section_name, extensions_used, bears):
@@ -51,16 +50,8 @@ def generate_ignore_field(project_dir,
     :return:
         A comma-separated string containing the globs to ignore.
     """
-
-    all_files = set(collect_files(
-        '**',
-        null_printer,
-        ignored_file_paths=ignore_globs))
-
     ignores = []
     for glob in ignore_globs:
-        gitignore_files = {file
-                           for file in collect_files([glob], null_printer)}
         ignores.append(os.path.relpath(glob, project_dir))
 
     return ', '.join(ignores)


### PR DESCRIPTION
The local variables all_files and gitignore_files were redundant
Hence they were removed.

Closes https://github.com/coala/coala-quickstart/issues/264