### PR TITLE
Project.py: Ask to select languages

### DIFF
--- a/coala_quickstart/Constants.py
+++ b/coala_quickstart/Constants.py
@@ -51,3 +51,9 @@ DEFAULT_CAPABILTIES = {
 }
 
 HASHBANG_REGEX = '(^#!(.*))'
+
+ASK_TO_SELECT_LANG = ('Which languages would you like to generate a config '
+                      'file for?\n'
+                      'Please select some languages using '
+                      'their numbers or just press \'Enter\' to select '
+                      'all of them\n')

--- a/tests/generation/BearsTest.py
+++ b/tests/generation/BearsTest.py
@@ -144,8 +144,7 @@ class TestBears(unittest.TestCase):
                                     self.arg_parser,
                                     {})
         all_bears = get_filtered_bears(['Python', 'C'])[0]
-        bears = all_bears['all']
-        bears += all_bears['all.python']
+        bears = all_bears['cli']
         important_bears = []
 
         for bear_set in list(IMPORTANT_BEAR_LIST.values()):

--- a/tests/generation/ProjectTest.py
+++ b/tests/generation/ProjectTest.py
@@ -1,9 +1,15 @@
 import unittest
 
 from pyprint.ConsolePrinter import ConsolePrinter
-from coala_utils.ContextManagers import retrieve_stdout
+from coala_utils.ContextManagers import (
+    retrieve_stdout,
+    simulate_console_inputs,
+    )
 from coala_quickstart.generation.Project import (
-    get_used_languages, print_used_languages)
+    ask_to_select_languages,
+    get_used_languages,
+    print_used_languages,
+    )
 
 
 class TestPopularLanguages(unittest.TestCase):
@@ -36,6 +42,16 @@ class TestPopularLanguages(unittest.TestCase):
             self.assertIn("Python", res)
             self.assertIn("100%", res)
 
+            print_used_languages(self.printer, [('Python', 100)], False)
+            res = custom_stdout.getvalue()
+            self.assertIn("Python", res)
+            self.assertIn("100%", res)
+
+            ask_to_select_languages([('Python', 100)], self.printer, True)
+            res = custom_stdout.getvalue()
+            self.assertIn("Python", res)
+            self.assertIn("100%", res)
+
         with retrieve_stdout() as custom_stdout:
             print_used_languages(self.printer, [('Python', 75), ('C++', 25)])
             self.assertIn("75%\n", custom_stdout.getvalue())
@@ -44,3 +60,28 @@ class TestPopularLanguages(unittest.TestCase):
         with retrieve_stdout() as custom_stdout:
             print_used_languages(self.printer, [])
             self.assertNotIn("following langauges", custom_stdout.getvalue())
+
+
+class TestAskLanguages(unittest.TestCase):
+
+    def setUp(self):
+        self.printer = ConsolePrinter()
+
+    def test_ask_to_select_languages(self):
+        languages = [('lang1', 50), ('lang2', 25), ('language3', 25)]
+        res = []
+        with simulate_console_inputs('1 2') as generator:
+            res = ask_to_select_languages(languages, self.printer, False)
+            self.assertEqual(generator.last_input, 0)
+        self.assertEqual(res, [('lang1', 50), ('lang2', 25)])
+
+        with simulate_console_inputs('6', '1') as generator:
+            res = ask_to_select_languages(languages, self.printer, False)
+            self.assertEqual(generator.last_input, 1)
+        self.assertEqual(res, [('lang1', 50)])
+
+        with simulate_console_inputs('\n') as generator:
+            res = ask_to_select_languages(languages, self.printer, False)
+            self.assertEqual(generator.last_input, 0)
+        self.assertEqual(res, [('lang1', 50), ('lang2', 25),
+                               ('language3', 25)])


### PR DESCRIPTION
* The interactive mode of coala-quickstart now asks to select
  languages too.
* The green_mode of coala-quickstart also asks to
  select languages by default. This behaviour can be overridden
  by the use of the non_interactive tag.
* Two new arguments are introduced max_args and max_values to be
  used along side the green_mode to specify the maximum amount
  of optional settings for the bears to test against and the
  maximum values that can be guessed against each optional setting
  respectively.
* Other minor changes include refactoring of some variables from
  global to local scope and addition of tests.