### PR TITLE
green_modeTest.py: Remove test_unified_results

### DIFF
--- a/tests/green_mode/green_modeTest.py
+++ b/tests/green_mode/green_modeTest.py
@@ -365,12 +365,6 @@ class Test_green_mode(unittest.TestCase):
                                 [{'filename': 'A.py'},
                                  {'filename': 'C.py'}]},
                                {TestGlobalBear: [{}]}]
-        test_unified_results = [{TestLocalBear:
-                                 [{'filename': 'A.py',
-                                   'yield_results': False},
-                                  {'filename': 'C.py',
-                                   'yield_results': False}]},
-                                {TestGlobalBear: [{'yield_results': False}]}]
         self.assertCountEqual(non_op_results[1][TestGlobalBear],
                               test_non_op_results[1][TestGlobalBear])
         self.assertCountEqual(non_op_results[0][TestLocalBear],


### PR DESCRIPTION
This change removes test_unified_results from test_bear_test_fun_2.
The expected results of unified_results are [None, None], so
test_unified_results can be removed.

Closes https://github.com/coala/coala-quickstart/issues/302