### PR TITLE
green_mode_core.py: Remove unnecessary import

### DIFF
--- a/coala_quickstart/green_mode/green_mode_core.py
+++ b/coala_quickstart/green_mode/green_mode_core.py
@@ -50,8 +50,6 @@ def green_mode(project_dir: str, ignore_globs, bears, bear_settings_obj,
         The maximum number of values to run the bear again and again for
         a optional setting.
     """
-    from coala_quickstart.green_mode.filename_operations import (
-        check_filename_prefix_postfix)
     ignore_globs.append(os.path.join(project_dir, '.git', '**'))
     project_data = project_dir + os.sep + PROJECT_DATA
 


### PR DESCRIPTION
Removed the delayed import of function check_filename_prefix_postfix
as it was already been called once , hence delayed import was
unnecessary

Closes https://github.com/coala/coala-quickstart/issues/300